### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/andycaine/jstink/security/code-scanning/1](https://github.com/andycaine/jstink/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block either at the root level or within the job definition. Since all jobs in the current workflow appear to only need to read repository contents to check out code and run tests, it is best to set `contents: read` as the least-privilege starting point. The recommended approach is to place the `permissions` block at the root/top level of the workflow file (just after the `name` and before the `on` block) so that it applies to all jobs unless overridden. No method changes or imports are needed since this is a configuration change in the workflow YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
